### PR TITLE
Updating sponsorship page with claimed items

### DIFF
--- a/src/DDDSouthWest.Website/Features/Public/Page/sponsorship.cshtml
+++ b/src/DDDSouthWest.Website/Features/Public/Page/sponsorship.cshtml
@@ -9,6 +9,11 @@
     <page-banner title="Sponsorship"/>
 }
 
+@section Css
+{
+    <link href="/css/sponsorship.css" rel="stylesheet"/>
+}
+
 @section MainColBody {
 
     <h1>Sponsorship Opportunities</h1>
@@ -53,21 +58,19 @@
             </td>
             <td>&pound;1500+</td>
         </tr>
-        <tr>
-            <td>Welcome Pastry</td>
-            <td>
-                Your company name and logo displayed with the pastries on arrival
-            </td>
+        <tr class="claimed">
+            <td>Welcome Pastries <span class="claimed-tooltip">This item has been sponsored</span> </td>
+            <td>Your company name and logo displayed with the pastries on arrival</td>
             <td>&pound;300</td>
         </tr>
-        <tr>
-            <td>Lunchtime Pasties</td>
-            <td>Your company name and logo displayed with the pasties at lunch</td>
+        <tr class="claimed">
+            <td>Lunch <span class="claimed-tooltip">This item has been sponsored</span></td>
+            <td>Your company name and logo displayed with the lunch</td>
             <td>&pound;600</td>
         </tr>
-        <tr>
-            <td>Afternoon Cream Teas</td>
-            <td>Your company name and logo displayed with the afternoon cream teas</td>
+        <tr class="claimed">
+            <td>Afternoon Tea <span class="claimed-tooltip">This item has been sponsored</span></td>
+            <td>Your company name and logo displayed with the afternoon tea</td>
             <td>&pound;500</td>
         </tr>
         </tbody>

--- a/src/DDDSouthWest.Website/wwwroot/css/sponsorship.css
+++ b/src/DDDSouthWest.Website/wwwroot/css/sponsorship.css
@@ -1,0 +1,19 @@
+﻿.claimed {
+    background-color: #cbcbcb;
+    text-decoration: line-through;
+}
+
+.claimed-tooltip {
+    visibility: hidden;
+    text-decoration: none;
+    background-color: grey;
+    color: white;
+    position: absolute;
+    z-index: 1;
+    border-radius: 5px;
+    padding: 10px;
+}
+
+.claimed:hover .claimed-tooltip {
+    visibility: visible;
+}


### PR DESCRIPTION
Added a quick indication of items that have been sponsored (i.e. no longer available to be sponsored). Greyed out and striked out with a tooltip to explain why. 

Todo at a later date: hook this into the admin area.

![image](https://user-images.githubusercontent.com/17496002/168447037-f88a43e3-9565-48d8-bdaa-1f6abf64e85d.png)
